### PR TITLE
Using gevent timeout to ensure that we never block indefinitely

### DIFF
--- a/gcrawl/__init__.py
+++ b/gcrawl/__init__.py
@@ -4,6 +4,9 @@ import urllib3
 import requests
 import urlparse
 from .page import Page
+
+# Gevent!
+import gevent
 from gevent import sleep
 from gevent import monkey; monkey.patch_all()
 
@@ -12,10 +15,17 @@ logging.basicConfig()
 logger = logging.getLogger('gcrawl')
 logger.setLevel(logging.INFO)
 
+
+class TimeoutException(Exception):
+    '''A timeout happened'''
+    pass
+
+
 class Crawl(object):
+    '''A crawl of a set of urls'''
     # The headers that we'd like to use when making requests
     headers = {}
-    
+
     @staticmethod
     def crawl(job):
         # @Matt, this is where you'd describe your qless job. For
@@ -27,54 +37,66 @@ class Crawl(object):
         with file('%s-dump' % job.jid, 'w+') as f:
             import cPickle as pickle
             pickle.dump(results, f)
-        
         job.complete()
-    
-    def __init__(self, seed, allow_subdomains=False, max_pages=10, allow_redirects=False):
+
+    def __init__(self, seed, allow_subdomains=False, max_pages=10, allow_redirects=False, timeout=10):
         self.requests         = [seed]
         self.results          = []
         self.crawled          = 0
+        self.timeout          = 10
         self.allow_subdomains = allow_subdomains
         self.max_pages        = max_pages
         self.allow_redirects  = allow_redirects
-    
+
     def before(self):
         '''This is executed before we run the main crawl loop'''
         pass
-    
+
     def run(self):
+        '''Run the crawl!'''
         self.before()
         while self.requests and self.crawled < self.max_pages:
             url = self.pop()
             try:
                 logger.info('Requesting %s' % url)
                 try:
-                    page = Page(requests.get(url, headers=self.headers, allow_redirects=self.allow_redirects))
-                except Exception as e:
-                    r = self.exception(url, e)
-                    if r:
-                        self.results.append(r)
+                    page = None
+                    with gevent.timeout.Timeout(self.timeout, False):
+                        page = Page(requests.get(url, headers=self.headers,
+                            allow_redirects=self.allow_redirects))
+                    if page is None:
+                        logger.warn('Timed out fetching %s' % url)
+                        raise TimeoutException('Url %s timed out' % url)
+                except Exception as exc:
+                    res = self.exception(url, exc)
+                    if res:
+                        self.results.append(res)
                     continue
-                
+
                 # Should we append these results?
-                r = self.got(page)
-                if r:
-                    self.results.append(r)
-                
+                res = self.got(page)
+                if res:
+                    self.results.append(res)
+
                 if self.count(page):
                     self.crawled += 1
-                
-                sleep(self.delay(page))
-            except Exception as e:
+
+                delay = None
+                with gevent.timeout.Timeout(self.timeout, False):
+                    delay = self.delay(page)
+                    sleep(delay)
+                if delay is None:
+                    logger.warn('Timed out getting dealy for %s' % url)
+            except Exception as exc:
                 logger.exception('Failed to request %s' % url)
-        
+
         self.after()
         return self.results
-    
+
     def after(self):
         '''This is executed after we run the main crawl loop, befor returning'''
         pass
-    
+
     def delay(self, page):
         '''How long to wait before sending the next request'''
         hostname = urlparse.urlparse(page.url).hostname
@@ -82,11 +104,11 @@ class Crawl(object):
             # No delay if the request was to localhost
             return 0
         return 2
-    
+
     def pop(self):
         '''Get the next url we should fetch'''
         return self.requests.pop(0)
-    
+
     def extend(self, urls, page):
         '''Add these urls to the list of requests we have to make'''
         self.requests.extend(urls)


### PR DESCRIPTION
It turns out that the `gevent` timeout only applies to connecting to a remote site, and not the whole transfer. This explicitly forces us to abort a fetch if the provided timeout is exceeded.
